### PR TITLE
公式及表格横向滚动视图

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -91,6 +91,12 @@ ul {
 .octicon {
   @apply mr-1 w-3;
 }
+
+.katex {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
 /* animation */
 
 @keyframes anvil {
@@ -127,6 +133,8 @@ ul {
 
 .table {
   @apply w-full border-collapse my-4;
+  overflow-x: auto;
+  display: block !important;
 }
 
 .table th,


### PR DESCRIPTION
在编写有超长公式和带有公式的表格时会出现溢出问题。#217
这里用CSS做了个滚动，仅当溢出时显示。