### PR TITLE
chore: format frontendUrl

### DIFF
--- a/server/src/services/rss.ts
+++ b/server/src/services/rss.ts
@@ -58,7 +58,7 @@ export function RSSService() {
 }
 
 export async function rssCrontab(env: Env) {
-    const frontendUrl = env.FRONTEND_URL;
+    const frontendUrl = `${(env.FRONTEND_URL.startsWith("http://") || env.FRONTEND_URL.startsWith("https://") ? '' :'https://')}${env.FRONTEND_URL}`;
     const db = drizzle(env.DB, { schema: schema })
     let title = env.RSS_TITLE;
     const description = env.RSS_DESCRIPTION || "Feed from Rin";


### PR DESCRIPTION
避免`FRONTEND_URL`变量没填协议导致rss文章的链接不正确