### PR TITLE
fix: update broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ Full documentation is available at https://docs.openrin.org.
 
 ## Star History
 
-<a href="https://star-history.com/#openRin/Rin&Date">
+<a href="https://star-history.dera.page/#openRin/Rin&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=openRin/Rin&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=openRin/Rin&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=openRin/Rin&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=openRin/Rin&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=openRin/Rin&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=openRin/Rin&type=Date" />
  </picture>
 </a>
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -137,11 +137,11 @@ bun run deploy:client
 
 ## Star 历史
 
-<a href="https://star-history.com/#openRin/Rin&Date">
+<a href="https://star-history.dera.page/#openRin/Rin&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=openRin/Rin&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=openRin/Rin&type=Date" />
-   <img alt="Star 历史图表" src="https://api.star-history.com/svg?repos=openRin/Rin&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=openRin/Rin&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=openRin/Rin&type=Date" />
+   <img alt="Star 历史图表" src="https://star-history.dera.page/svg?repos=openRin/Rin&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the stargazer data source relies on a restricted GitHub API. This change repoints the chart to a working provider that needs no API token, restoring the chart in both the English and Chinese READMEs.