### PR TITLE
fix: 修复文章详情页右侧导航滚动位置 (#557)

### DIFF
--- a/client/src/hooks/__tests__/use-table-of-contents.test.tsx
+++ b/client/src/hooks/__tests__/use-table-of-contents.test.tsx
@@ -1,0 +1,84 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import useTableOfContents from "../useTableOfContents";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+class MockIntersectionObserver {
+  static latest: MockIntersectionObserver;
+
+  readonly root = null;
+  readonly rootMargin = "0px";
+  readonly thresholds = [0];
+
+  constructor(private readonly callback: IntersectionObserverCallback) {
+    MockIntersectionObserver.latest = this;
+  }
+
+  disconnect = vi.fn();
+  observe = vi.fn();
+  takeRecords = vi.fn(() => []);
+  unobserve = vi.fn();
+
+  trigger(entries: Array<Pick<IntersectionObserverEntry, "isIntersecting" | "target">>) {
+    this.callback(entries as IntersectionObserverEntry[], this as unknown as IntersectionObserver);
+  }
+}
+
+function TableOfContentsHarness() {
+  const { TOC } = useTableOfContents(".toc-content");
+
+  return (
+    <>
+      <article className="toc-content">
+        <h2>Introduction</h2>
+        <h2>Details</h2>
+        <h2>Conclusion</h2>
+      </article>
+      <aside>
+        <TOC />
+      </aside>
+    </>
+  );
+}
+
+describe("useTableOfContents", () => {
+  beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+    vi.stubGlobal("scrollTo", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves the navigation scroll position when the active heading changes", async () => {
+    render(<TableOfContentsHarness />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    });
+
+    const tocList = screen.getByRole("list");
+    tocList.scrollTop = 96;
+
+    fireEvent.click(screen.getAllByRole("listitem")[1]);
+
+    const headings = document.querySelectorAll<HTMLElement>(".toc-content h2");
+    act(() => {
+      MockIntersectionObserver.latest.trigger([
+        { target: headings[2], isIntersecting: true },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("listitem")[1]).toHaveClass("text-theme");
+    });
+    expect(screen.getByRole("list").scrollTop).toBe(96);
+  });
+});

--- a/client/src/hooks/__tests__/use-table-of-contents.test.tsx
+++ b/client/src/hooks/__tests__/use-table-of-contents.test.tsx
@@ -1,5 +1,7 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../test/setup";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import useTableOfContents from "../useTableOfContents";
 
 vi.mock("react-i18next", () => ({
@@ -29,6 +31,23 @@ class MockIntersectionObserver {
   }
 }
 
+const originalIntersectionObserver = Object.getOwnPropertyDescriptor(globalThis, "IntersectionObserver");
+const originalGetComputedStyle = Object.getOwnPropertyDescriptor(globalThis, "getComputedStyle");
+const originalReactActEnvironment = Object.getOwnPropertyDescriptor(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+const originalScrollTo = Object.getOwnPropertyDescriptor(window, "scrollTo");
+
+function restoreGlobal(
+  target: typeof globalThis | Window,
+  key: "IntersectionObserver" | "getComputedStyle" | "IS_REACT_ACT_ENVIRONMENT" | "scrollTo",
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+  } else {
+    Reflect.deleteProperty(target, key);
+  }
+}
+
 function TableOfContentsHarness() {
   const { TOC } = useTableOfContents(".toc-content");
 
@@ -47,27 +66,57 @@ function TableOfContentsHarness() {
 }
 
 describe("useTableOfContents", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
   beforeEach(() => {
-    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
-    vi.stubGlobal("scrollTo", vi.fn());
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      value: MockIntersectionObserver,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "getComputedStyle", {
+      configurable: true,
+      value: window.getComputedStyle.bind(window),
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+      configurable: true,
+      value: true,
+      writable: true,
+    });
+    Object.defineProperty(window, "scrollTo", {
+      configurable: true,
+      value: vi.fn(),
+      writable: true,
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
   });
 
   afterEach(() => {
-    cleanup();
-    vi.unstubAllGlobals();
+    act(() => root.unmount());
+    container.remove();
+    restoreGlobal(globalThis, "IntersectionObserver", originalIntersectionObserver);
+    restoreGlobal(globalThis, "getComputedStyle", originalGetComputedStyle);
+    restoreGlobal(globalThis, "IS_REACT_ACT_ENVIRONMENT", originalReactActEnvironment);
+    restoreGlobal(window, "scrollTo", originalScrollTo);
   });
 
-  it("preserves the navigation scroll position when the active heading changes", async () => {
-    render(<TableOfContentsHarness />);
+  it("preserves the navigation scroll position when the active heading changes", () => {
+    act(() => root.render(<TableOfContentsHarness />));
 
-    await waitFor(() => {
-      expect(screen.getAllByRole("listitem")).toHaveLength(3);
-    });
+    const getTocItems = () => Array.from(container.querySelectorAll<HTMLElement>("aside li"));
+    expect(getTocItems()).toHaveLength(3);
 
-    const tocList = screen.getByRole("list");
+    const tocList = container.querySelector<HTMLElement>("aside ul")!;
     tocList.scrollTop = 96;
 
-    fireEvent.click(screen.getAllByRole("listitem")[1]);
+    act(() => {
+      getTocItems()[1].dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
 
     const headings = document.querySelectorAll<HTMLElement>(".toc-content h2");
     act(() => {
@@ -76,9 +125,7 @@ describe("useTableOfContents", () => {
       ]);
     });
 
-    await waitFor(() => {
-      expect(screen.getAllByRole("listitem")[1]).toHaveClass("text-theme");
-    });
-    expect(screen.getByRole("list").scrollTop).toBe(96);
+    expect(getTocItems()[1].classList.contains("text-theme")).toBe(true);
+    expect(container.querySelector<HTMLElement>("aside ul")!.scrollTop).toBe(96);
   });
 });

--- a/client/src/hooks/useTableOfContents.tsx
+++ b/client/src/hooks/useTableOfContents.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export interface TableOfContent {
@@ -83,8 +83,13 @@ const useTableOfContents = (selector: string) => {
         if (io.current) io.current.disconnect()
     }
 
-    return {
-        TOC: () => (<div className='rounded-2xl bg-w py-4 px-4 t-primary'>
+    const tocStateRef = useRef({ tableOfContents, activeIndex, t })
+    tocStateRef.current = { tableOfContents, activeIndex, t }
+
+    const TOC = useCallback(() => {
+        const { tableOfContents, activeIndex, t } = tocStateRef.current
+
+        return <div className='rounded-2xl bg-w py-4 px-4 t-primary'>
             <h2 className="text-lg font-bold">{t("index.title")}</h2>
             <ul className="max-h-[calc(100vh-10.25rem)] overflow-auto" style={{ scrollbarWidth: "none" }}>
                 {tableOfContents.length === 0 && <li>{t("index.empty.title")}</li>}
@@ -105,7 +110,11 @@ const useTableOfContents = (selector: string) => {
                     </li>
                 ))}
             </ul>
-        </div>), cleanup
+        </div>
+    }, [])
+
+    return {
+        TOC, cleanup
     }
 }
 


### PR DESCRIPTION
## 问题与根因

Closes #557

文章详情页 TOC 由 useTableOfContents 返回内联组件函数。IntersectionObserver 更新 activeIndex 后，hook 重渲染并生成新的组件函数引用；React 将其视为新的组件类型，重新挂载 TOC DOM，导致目录滚动容器的 scrollTop 复位到 0。

## 修复

- 保持 TOC 组件引用稳定，并通过 ref 读取最新目录数据、高亮索引和翻译函数。
- 保留现有 IntersectionObserver 章节判断与点击滚动算法，仅修复重挂载问题。

## TDD

1. 红：新增回归测试，预设目录 scrollTop = 96，模拟点击目录项及 IntersectionObserver 更新；修复前实际值变为 0。
2. 绿：最小修复后高亮正常更新，目录滚动位置保持为 96。

## 验证

- 定向 Vitest：1 passed
- 全量客户端测试：7 files / 28 tests passed
- 客户端 TypeScript（tsc）：通过
- 新增测试 ESLint：通过
- 改动文件 ESLint：0 errors，仅剩 hook 原有 selector 依赖 warning
- 全量 lint 仍受仓库既有基线问题影响