### PR TITLE
fix: restore missing feeds.top column (supersedes #565)

### DIFF
--- a/cli/src/commands/db.ts
+++ b/cli/src/commands/db.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "node:util";
-import { fixTopField, isInfoExist } from "../lib/db-migration";
+import { fixTopField } from "../lib/db-migration";
 import { runLocalDbMigrate } from "../tasks/db-migrate-local";
 
 export async function runDbCommand(args: string[]) {
@@ -19,8 +19,7 @@ export async function runDbCommand(args: string[]) {
   }
 
   if (subcommand === "fix-top-field") {
-    const infoExists = await isInfoExist("local", dbName);
-    await fixTopField("local", dbName, infoExists);
+    await fixTopField("local", dbName);
     return;
   }
 

--- a/cli/src/lib/db-migration.ts
+++ b/cli/src/lib/db-migration.ts
@@ -50,13 +50,11 @@ async function runWranglerQuiet(args: string[]) {
   }
 }
 
-export async function fixTopField(type: "local" | "remote", db: string, infoExists: boolean) {
-  if (infoExists) {
-    console.log("New database, skip top field check");
-    return;
-  }
-
-  console.log("Legacy database, check top field");
+export async function fixTopField(type: "local" | "remote", db: string) {
+  // The `info` table existing only tells us the database went through 0002.sql;
+  // it says nothing about whether `feeds.top` exists. The column was never
+  // created by any migration (see server/sql/0012.sql), so we must always
+  // probe the column itself instead of inferring from `infoExists`.
   const result = await runWranglerJson([
     "d1",
     "execute",

--- a/cli/src/tasks/db-migrate-local.ts
+++ b/cli/src/tasks/db-migrate-local.ts
@@ -1,14 +1,13 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execSync } from "node:child_process";
-import { fixTopField, getMigrationFileVersion, getMigrationVersion, isInfoExist, updateMigrationVersion } from "../lib/db-migration";
+import { fixTopField, getMigrationFileVersion, getMigrationVersion, updateMigrationVersion } from "../lib/db-migration";
 
 export async function runLocalDbMigrate(dbName = "rin") {
   const sqlDir = path.join(process.cwd(), "server", "sql");
 
   const type = "local";
   const migrationVersion = await getMigrationVersion(type, dbName);
-  const infoExists = await isInfoExist(type, dbName);
   const sqlFiles = fs
     .readdirSync(sqlDir, { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
@@ -43,5 +42,5 @@ export async function runLocalDbMigrate(dbName = "rin") {
     }
   }
 
-  await fixTopField(type, dbName, infoExists);
+  await fixTopField(type, dbName);
 }

--- a/cli/src/tasks/deploy-cf.ts
+++ b/cli/src/tasks/deploy-cf.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { readdir, unlink } from "node:fs/promises";
 import stripIndent from "strip-indent";
-import { fixTopField, getMigrationFileVersion, getMigrationVersion, isInfoExist, updateMigrationVersion } from "../lib/db-migration";
+import { fixTopField, getMigrationFileVersion, getMigrationVersion, updateMigrationVersion } from "../lib/db-migration";
 const bunExec = process.execPath;
 
 function env(name: string, defaultValue?: string, required = false) {
@@ -267,7 +267,6 @@ export async function runCloudflareDeploy(target: "all" | "server" | "client" = 
   }
 
   const migrationVersion = await getMigrationVersion("remote", dbName);
-  const infoExists = await isInfoExist("remote", dbName);
   const files = await readdir("./server/sql", { recursive: false });
   const sqlFiles = files
     .filter((name) => name.endsWith(".sql"))
@@ -289,7 +288,7 @@ export async function runCloudflareDeploy(target: "all" | "server" | "client" = 
       await updateMigrationVersion("remote", dbName, lastVersion);
     }
   }
-  await fixTopField("remote", dbName, infoExists);
+  await fixTopField("remote", dbName);
 
   if (target === "server") {
     await $`${bunExec} x wrangler deploy`;

--- a/scripts/__tests__/feeds-top-migration.test.ts
+++ b/scripts/__tests__/feeds-top-migration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { getMigrationFileVersion } from '../../cli/src/lib/db-migration';
+
+const SQL_DIR = new URL('../../server/sql/', import.meta.url).pathname;
+
+function splitStatements(sql: string): string[] {
+    return sql
+        .split('--> statement-breakpoint')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+
+/** Build a database in the broken state: migrated to 0011 but without feeds.top. */
+function createBrokenDatabase(): Database {
+    const db = new Database(':memory:');
+    db.exec(`
+        CREATE TABLE users (id integer PRIMARY KEY NOT NULL, openid text);
+        CREATE TABLE feeds (
+            id integer PRIMARY KEY NOT NULL,
+            alias text, title text, content text NOT NULL,
+            summary text DEFAULT '' NOT NULL,
+            listed integer DEFAULT 1 NOT NULL,
+            draft integer DEFAULT 1 NOT NULL,
+            uid integer NOT NULL,
+            created_at integer, updated_at integer
+        );
+        CREATE TABLE info (key text NOT NULL, value text NOT NULL);
+        INSERT INTO info (key, value) VALUES ('migration_version', '11');
+        INSERT INTO feeds (id, title, content, uid) VALUES (1, 'a', 'x', 1);
+    `);
+    return db;
+}
+
+describe('feeds.top 迁移修复', () => {
+    it('0011.sql 在没有 top 列时会失败，复现原始缺陷', async () => {
+        const db = createBrokenDatabase();
+        const sql = await Bun.file(`${SQL_DIR}0011.sql`).text();
+        const stmts = splitStatements(sql);
+        // 只取 feeds_visibility_order_idx 这条语句（其它建索引语句与本缺陷无关）
+        const idxStmt = stmts.find((s) => s.includes('feeds_visibility_order_idx'))!;
+        expect(() => db.exec(idxStmt)).toThrow();
+        db.close();
+    });
+
+    it('0012.sql 能修复缺失的 top 列并重建索引', async () => {
+        const db = createBrokenDatabase();
+        const sql = await Bun.file(`${SQL_DIR}0012.sql`).text();
+        for (const stmt of splitStatements(sql)) {
+            db.exec(stmt);
+        }
+
+        const columns = db
+            .query("PRAGMA table_info('feeds')")
+            .all()
+            .map((r) => (r as { name: string }).name);
+        expect(columns).toContain('top');
+
+        const version = db
+            .query("SELECT value FROM info WHERE key='migration_version'")
+            .get() as { value: string };
+        expect(version.value).toBe('12');
+
+        const idxCols = db
+            .query("PRAGMA index_info('feeds_visibility_order_idx')")
+            .all()
+            .map((r) => (r as { name: string }).name);
+        expect(idxCols).toEqual(['draft', 'listed', 'top', 'created_at', 'updated_at']);
+
+        db.close();
+    });
+
+    it('0012.sql 只会在版本号低于 12 的数据库上执行', () => {
+        const files = ['0011.sql', '0012.sql'];
+        // 模拟 runner 的过滤逻辑：version > migrationVersion
+        const select = (migrationVersion: number) =>
+            files.filter((f) => {
+                const v = getMigrationFileVersion(f);
+                return v !== null && v > migrationVersion;
+            });
+
+        // 尚未升级到 0011 的库：0011、0012 都会执行
+        expect(select(10)).toEqual(['0011.sql', '0012.sql']);
+        // 已经卡在 0011 的库：0012 仍会执行，这正是修改 0011 无法覆盖的场景
+        expect(select(11)).toEqual(['0012.sql']);
+        // 已修复的库：不再重复执行
+        expect(select(12)).toEqual([]);
+    });
+});

--- a/server/sql/0012.sql
+++ b/server/sql/0012.sql
@@ -1,0 +1,36 @@
+-- Restore the `top` column on `feeds`.
+--
+-- Background: `top` was introduced in 690a21e ("feat: add top support") together
+-- with a 0002.sql migration. Later 0002.sql was rewritten (b3907cf, then
+-- aacb021 "fix: new database migration strategy") and the `ADD COLUMN` for
+-- `top` was dropped, while src/db/schema.ts kept the field. The result is a
+-- schema drift: the ORM expects `feeds.top` but no migration ever created it.
+--
+-- This stayed hidden because no migration SQL referenced `top` until 0011.sql
+-- created `feeds_visibility_order_idx` on it. On databases that ran 0011
+-- without the column, that CREATE INDEX fails (or is silently skipped by
+-- `IF NOT EXISTS`, which only checks the index name -- not the columns).
+--
+-- Why a new 0012.sql instead of editing 0011.sql: the migration runner only
+-- executes files whose version is strictly greater than the current
+-- `migration_version` (see getMigrationFileVersion filter in
+-- cli/src/tasks/db-migrate-local.ts and cli/src/tasks/deploy-cf.ts).
+-- Databases already at version 11 would skip an edited 0011.sql entirely,
+-- so the fix would never reach the databases that are actually broken.
+--
+-- Note: SQLite does not support `ADD COLUMN IF NOT EXISTS`. The runner's
+-- `version > migrationVersion` filter already makes this idempotent in
+-- practice: it runs once for any database below 12, and never again after
+-- `migration_version` is set to 12 below.
+
+ALTER TABLE `feeds` ADD COLUMN `top` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+
+-- `feeds_visibility_order_idx` from 0011.sql may be missing or may have been
+-- created without `top` available. Recreate it now that the column exists.
+DROP INDEX IF EXISTS `feeds_visibility_order_idx`;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `feeds_visibility_order_idx` ON `feeds` (`draft`, `listed`, `top`, `created_at`, `updated_at`);
+--> statement-breakpoint
+
+UPDATE `info` SET `value` = '12' WHERE `key` = 'migration_version';


### PR DESCRIPTION
Closes #565 (supersedes it — see rationale below).

## Problem

`feeds.top` is declared in `server/src/db/schema.ts` but **no migration has ever created it**.

- `690a21e` ("feat: add top support") added the field together with an `ALTER TABLE feeds ADD top` in `0002.sql`.
- `b3907cf` rewrote `0002.sql` to a `feeds_new` table rebuild (still carrying `top`), then `aacb021` ("fix: new database migration strategy") replaced `0002.sql` wholesale with the `info` table + `migration_version` bootstrap — **dropping the `ADD COLUMN` while `schema.ts` kept the field**.

This stayed invisible for a long time because no migration SQL mentioned `top` at all. That changed in `151942f`, where `0011.sql` created an index on it:

```sql
CREATE INDEX IF NOT EXISTS `feeds_visibility_order_idx`
  ON `feeds` (`draft`, `listed`, `top`, `created_at`, `updated_at`);
```

On a database without the column this fails. Worse, `IF NOT EXISTS` only checks the *index name*, not the columns, so it can also be skipped silently and leave the index missing.

## Why this supersedes #565

#565 puts the `ALTER TABLE` at the top of **`0011.sql`**. The intent is right, but the runner only executes files whose version is *strictly greater* than the current `migration_version`:

```ts
.filter((file) => version !== null && version > migrationVersion)
```

Since `0011.sql` ends by setting `migration_version = 11`, an edited `0011.sql` is skipped by every database already at 11 — **precisely the databases that are broken**. It would only help databases that have not yet reached 0011, which are not the ones reporting the error.

This PR adds `server/sql/0012.sql` instead, which the same filter *does* pick up at version 11.

| current version | files executed | result |
| --- | --- | --- |
| 10 | 0011, 0012 | fixed |
| 11 | 0012 | **fixed** (the case #565 cannot reach) |
| 12 | — | no-op |

## Changes

- **`server/sql/0012.sql`** (new) — restores the column, recreates the index, bumps the version:
  ```sql
  ALTER TABLE `feeds` ADD COLUMN `top` integer DEFAULT 0 NOT NULL;
  DROP INDEX IF EXISTS `feeds_visibility_order_idx`;
  CREATE INDEX IF NOT EXISTS `feeds_visibility_order_idx` ON `feeds` (...);
  UPDATE `info` SET `value` = '12' WHERE `key` = 'migration_version';
  ```
  The index is recreated because a previous 0011 run may have left it missing or unusable. Note SQLite has no `ADD COLUMN IF NOT EXISTS`; idempotency comes from the runner's version filter, which runs this once and then never again.

- **`cli/src/lib/db-migration.ts`** — fixes `fixTopField()`, which inferred the column's presence from whether the `info` table exists:
  ```ts
  if (infoExists) { return; }   // before
  ```
  Those two facts are unrelated: `info` is created by `0002.sql`, while `top` was created by nothing at all — so *every* database with an `info` table skipped the check, making the fallback dead code. It now probes `pragma_table_info('feeds')` directly, which is correct for both legacy and fresh databases. The unused `infoExists` parameter is dropped and call sites updated.

- **`scripts/__tests__/feeds-top-migration.test.ts`** (new) — regression tests for the 0011 failure, the 0012 repair, and the runner's version filter.

## Testing

```
bun test scripts/__tests__   -> 86 pass, 0 fail
bun test cli                 -> 40 pass, 0 fail
tsc --noEmit -p cli/tsconfig.json -> clean
```

The tests build an in-memory SQLite database in the broken state (migrated to 11, no `top` column), confirm 0011's index statement genuinely throws, then confirm 0012 produces the column, the version bump, and an index whose columns include `top`.
