### PR TITLE
fix(search,storage): escape LIKE wildcards in feed search & add default CORS/Cache-Control headers to storage responses

### DIFF
--- a/server/src/features/feed/repository.ts
+++ b/server/src/features/feed/repository.ts
@@ -37,8 +37,20 @@ export type SearchFeedPageOptions = {
     limit: number;
 };
 
+function escapeLikePattern(keyword: string): string {
+    return keyword.replace(/[%_\\]/g, (char) => `\\${char}`);
+}
+
 export async function searchFeedPage(db: DB, options: SearchFeedPageOptions) {
-    const searchPattern = `%${options.keyword}%`;
+    const trimmed = options.keyword ? options.keyword.trim() : "";
+    if (!trimmed) {
+        return {
+            size: 0,
+            rows: [],
+            hasNext: false,
+        };
+    }
+    const searchPattern = `%${escapeLikePattern(trimmed)}%`;
     const searchWhere = or(
         like(feeds.title, searchPattern),
         like(feeds.content, searchPattern),

--- a/server/src/utils/storage.ts
+++ b/server/src/utils/storage.ts
@@ -88,6 +88,14 @@ function createStorageResponse(object: R2ObjectBody | R2Object, body?: BodyInit 
     headers.set("Last-Modified", object.uploaded.toUTCString());
   }
 
+  if (!headers.has("Cache-Control")) {
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  }
+
+  if (!headers.has("Access-Control-Allow-Origin")) {
+    headers.set("Access-Control-Allow-Origin", "*");
+  }
+
   return new Response(body ?? null, {
     status: 200,
     headers,


### PR DESCRIPTION
### Summary
This PR improves search safety in feed repository queries and enhances R2/S3 storage response headers.

### Key Changes
1. **Search Wildcard Escaping (`searchFeedPage`)**:
   - Escapes `%`, `_`, and `\` in user search queries to prevent unintentional table-wide wildcard matching.
   - Gracefully handles empty or whitespace-only search keywords without unnecessary database queries.
2. **Storage Response Headers (`createStorageResponse`)**:
   - Adds default `Cache-Control: public, max-age=31536000, immutable` and `Access-Control-Allow-Origin: *` headers to R2 blob object responses for optimal caching and cross-origin resource embedding.